### PR TITLE
Patch Vec constructors to alloc with Boehm

### DIFF
--- a/src/liballoc/boehm.rs
+++ b/src/liballoc/boehm.rs
@@ -1,0 +1,48 @@
+#![allow(missing_docs)]
+use core::ffi::c_void;
+use core::ptr::NonNull;
+
+#[stable(feature = "alloc_module", since = "1.28.0")]
+#[doc(inline)]
+use core::alloc::*;
+
+#[derive(Debug)]
+pub struct BoehmAllocator;
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl AllocRef for BoehmAllocator {
+    fn alloc(&mut self, layout: Layout, _init: AllocInit) -> Result<MemoryBlock, AllocErr> {
+        let ptr = unsafe { GC_malloc(layout.size()) } as *mut u8;
+        assert!(!ptr.is_null());
+        Ok(MemoryBlock { ptr: unsafe { NonNull::new_unchecked(ptr) }, size: layout.size() })
+    }
+
+    unsafe fn dealloc(&mut self, _: NonNull<u8>, _: Layout) {}
+}
+
+#[link(name = "gc")]
+extern "C" {
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_gcollect();
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_malloc(nbytes: usize) -> *mut c_void;
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_malloc_uncollectable(nbytes: usize) -> *mut c_void;
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_realloc(old: *mut c_void, new_size: usize) -> *mut c_void;
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_free(dead: *mut c_void);
+
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn GC_register_finalizer(
+        ptr: *mut c_void,
+        finalizer: unsafe extern "C" fn(*mut c_void, *mut c_void),
+        client_data: *mut c_void,
+        old_finalizer: *mut extern "C" fn(*mut c_void, *mut c_void),
+        old_client_data: *mut *mut c_void,
+    );
+}

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -170,6 +170,9 @@ pub mod task;
 mod tests;
 pub mod vec;
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub mod boehm;
+
 #[cfg(not(test))]
 mod std {
     pub use core::ops; // RangeFull

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -72,11 +72,11 @@ use core::ops::{self, Index, IndexMut, RangeBounds};
 use core::ptr::{self, NonNull};
 use core::slice::{self, SliceIndex};
 
+use crate::boehm::BoehmGcAllocator;
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::collections::TryReserveError;
 use crate::raw_vec::RawVec;
-use crate::boehm::BoehmGcAllocator;
 
 /// A contiguous growable array type, written `Vec<T>` but pronounced 'vector'.
 ///
@@ -306,6 +306,39 @@ pub struct Vec<T> {
 ////////////////////////////////////////////////////////////////////////////////
 // Inherent methods
 ////////////////////////////////////////////////////////////////////////////////
+
+#[cfg_attr(not(bootstrap), lang = "vec_with_capacity_gc")]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow(missing_docs)]
+#[allow(unused_variables)]
+pub fn vec_with_capacity_gc<T>(capacity: usize) -> Vec<T> {
+    let temp_buf = RawVec::with_capacity_in(capacity, BoehmGcAllocator);
+    unsafe { Vec { buf: RawVec::from_raw_parts(temp_buf.ptr(), temp_buf.capacity()), len: 0 } }
+}
+
+#[cfg_attr(not(bootstrap), lang = "vec_push_gc")]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow(missing_docs)]
+#[allow(unused_variables)]
+pub fn push<T>(vec: &mut Vec<T>, value: T) {
+    // This will panic or abort if we would allocate > isize::MAX bytes
+    // or if the length increment would overflow for zero-sized types.
+    if vec.len == vec.buf.capacity() {
+        let mut tmp_buf = unsafe {
+            RawVec::from_raw_parts_in(vec.buf.ptr(), vec.buf.capacity(), BoehmGcAllocator)
+        };
+        tmp_buf.reserve(vec.len(), 1);
+
+        // we must now reconstruct the original buffer with the new capacity
+        // as it will be unaware of the allocation.
+        vec.buf = unsafe { RawVec::from_raw_parts(tmp_buf.ptr(), tmp_buf.capacity()) };
+    }
+    unsafe {
+        let end = vec.as_mut_ptr().add(vec.len);
+        ptr::write(end, value);
+        vec.len += 1;
+    }
+}
 
 impl<T> Vec<T> {
     /// Constructs a new, empty `Vec<T>`.

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -76,6 +76,7 @@ use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::collections::TryReserveError;
 use crate::raw_vec::RawVec;
+use crate::boehm::BoehmGcAllocator;
 
 /// A contiguous growable array type, written `Vec<T>` but pronounced 'vector'.
 ///

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -1,0 +1,9 @@
+#![stable(feature = "core", since = "1.6.0")]
+#![allow(missing_docs)]
+#[cfg(not(bootstrap))]
+#[stable(feature = "core", since = "1.6.0")]
+#[lang = "manageable_contents"]
+/// This trait can be implemented on types where it is safe to allow the allow the collector to
+/// free its memory and omit the drop method. This prevents the need to register a finalizer when
+/// managed by the Gc which is expensive.
+pub trait ManageableContents {}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -259,6 +259,8 @@ pub mod task;
 #[allow(missing_docs)]
 pub mod alloc;
 
+pub mod gc;
+
 // note: does not need to be public
 mod bool;
 mod tuple;

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -217,6 +217,9 @@ language_item_table! {
     PartialOrdTraitLangItem,     "partial_ord",        partial_ord_trait,       Target::Trait;
 
     ManageableContentsTraitLangItem, "manageable_contents", manageable_contents_trait, Target::Trait;
+    VecWithCapacityGCFnLangItem,    "vec_with_capacity_gc",       vec_with_capacity_fn,            Target::Fn;
+    VecPushGc,                 "vec_push_gc",    vec_push_gc_fn,       Target::Fn;
+
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The
     // `panic_bounds_check` item is for indexing arrays.

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -216,6 +216,7 @@ language_item_table! {
     EqTraitLangItem,             "eq",                 eq_trait,                Target::Trait;
     PartialOrdTraitLangItem,     "partial_ord",        partial_ord_trait,       Target::Trait;
 
+    ManageableContentsTraitLangItem, "manageable_contents", manageable_contents_trait, Target::Trait;
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The
     // `panic_bounds_check` item is for indexing arrays.

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -26,6 +26,7 @@ pub mod generator;
 pub mod inline;
 pub mod instcombine;
 pub mod no_landing_pads;
+pub mod preallocate_gc_contents;
 pub mod promote_consts;
 pub mod qualify_min_const_fn;
 pub mod remove_noop_landing_pads;
@@ -297,6 +298,7 @@ fn run_optimization_passes<'tcx>(
             &unreachable_prop::UnreachablePropagation,
             &uninhabited_enum_branching::UninhabitedEnumBranching,
             &simplify::SimplifyCfg::new("after-uninhabited-enum-branching"),
+            &preallocate_gc_contents::GcPreallocator,
             &inline::Inline,
             // Lowering generator control-flow and variables
             // has to happen before we do anything else to them.

--- a/src/librustc_mir/transform/preallocate_gc_contents.rs
+++ b/src/librustc_mir/transform/preallocate_gc_contents.rs
@@ -1,0 +1,112 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+use crate::transform::{MirPass, MirSource};
+use crate::util::patch::MirPatch;
+use rustc_infer::infer::TyCtxtInferExt;
+use rustc_middle::mir::*;
+use rustc_middle::traits;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::DUMMY_SP;
+use rustc_trait_selection::traits::predicate_for_trait_def;
+use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
+
+const VEC_WITH_CAPACITY: &str = "std::vec::Vec::<T>::with_capacity";
+const VEC_PUSH: &str = "std::vec::Vec::<T>::push";
+
+pub struct GcPreallocator;
+
+impl<'tcx> MirPass<'tcx> for GcPreallocator {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
+        let param_env = tcx.param_env(source.def_id()).with_reveal_all();
+
+        GcPatcher { tcx, source, param_env }.run_pass(body);
+    }
+}
+
+struct GcPatcher<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    source: MirSource<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+}
+
+impl GcPatcher<'tcx> {
+    fn run_pass(&mut self, body: &mut BodyAndCache<'tcx>) {
+        let mut patch = MirPatch::new(body);
+        for (bb, bb_data) in body.basic_blocks().iter_enumerated() {
+            let terminator = bb_data.terminator();
+            if let TerminatorKind::Call {
+                ref func,
+                ref args,
+                ref destination,
+                cleanup,
+                from_hir_call,
+            } = terminator.kind
+            {
+                if let ty::FnDef(callee_def_id, substs) = func.ty(&**body, self.tcx).kind {
+                    let name = self.tcx.def_path_str(callee_def_id);
+                    let new_term = match name.as_str() {
+                        VEC_WITH_CAPACITY => {
+                            if !ty_impls_manageable_contents(
+                                substs.type_at(0),
+                                self.tcx,
+                                self.param_env,
+                            ) {
+                                continue;
+                            }
+                            let new_callee = self.tcx.lang_items().vec_with_capacity_fn().unwrap();
+                            let func =
+                                Operand::function_handle(self.tcx, new_callee, substs, DUMMY_SP);
+                            TerminatorKind::Call {
+                                func,
+                                args: args.clone(),
+                                destination: destination.clone(),
+                                cleanup,
+                                from_hir_call,
+                            }
+                        }
+                        VEC_PUSH => {
+                            if !ty_impls_manageable_contents(
+                                substs.type_at(0),
+                                self.tcx,
+                                self.param_env,
+                            ) {
+                                continue;
+                            }
+                            let new_callee = self.tcx.lang_items().vec_push_gc_fn().unwrap();
+                            let func =
+                                Operand::function_handle(self.tcx, new_callee, substs, DUMMY_SP);
+                            TerminatorKind::Call {
+                                func,
+                                args: args.clone(),
+                                destination: destination.clone(),
+                                cleanup,
+                                from_hir_call,
+                            }
+                        }
+                        _ => continue,
+                    };
+                    patch.patch_terminator(bb, new_term);
+                }
+            }
+        }
+        patch.apply(body);
+    }
+}
+
+fn ty_impls_manageable_contents<'tcx>(
+    ty: Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+) -> bool {
+    let prealloc_trait_id = tcx.lang_items().manageable_contents_trait().unwrap();
+    let obligation = predicate_for_trait_def(
+        tcx,
+        param_env,
+        traits::ObligationCause::dummy(),
+        prealloc_trait_id,
+        0,
+        ty,
+        &[],
+    );
+    tcx.infer_ctxt().enter(|infcx| infcx.predicate_must_hold_modulo_regions(&obligation))
+}

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -234,6 +234,9 @@ unsafe impl AllocRef for System {
 }
 static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
+#[stable(feature = "alloc_system_type", since = "1.28.0")]
+pub use alloc_crate::boehm::BoehmAllocator as Boehm;
+
 /// Registers a custom allocation error hook, replacing any that was previously registered.
 ///
 /// The allocation error hook is invoked when an infallible memory allocation fails, before

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -1,4 +1,27 @@
 use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+const BOEHM_REPO: &str = "https://github.com/ivmai/bdwgc.git";
+const BOEHM_ATOMICS_REPO: &str = "https://github.com/ivmai/libatomic_ops.git";
+const BOEHM_DIR: &str = "bdwgc";
+const BUILD_DIR: &str = ".libs";
+
+#[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
+compile_error!("Requires x86_64 with 64 bit pointer width.");
+static POINTER_MASK: &str = "-DPOINTER_MASK=0xFFFFFFFFFFFFFFF8";
+static FPIC: &str = "-fPIC";
+
+fn run<F>(name: &str, mut configure: F)
+where
+    F: FnMut(&mut Command) -> &mut Command,
+{
+    let mut command = Command::new(name);
+    let configured = configure(&mut command);
+    if !configured.status().is_ok() {
+        panic!("failed to execute {:?}", configured);
+    }
+}
 
 fn main() {
     let target = env::var("TARGET").expect("TARGET was not set");
@@ -63,4 +86,33 @@ fn main() {
         println!("cargo:rustc-link-lib=c");
         println!("cargo:rustc-link-lib=compiler_rt");
     }
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let mut boehm_src = PathBuf::from(out_dir);
+    boehm_src.push(BOEHM_DIR);
+
+    if !boehm_src.exists() {
+        run("git", |cmd| cmd.arg("clone").arg("--depth=1").arg(BOEHM_REPO).arg(&boehm_src));
+
+        run("git", |cmd| {
+            cmd.arg("clone").arg("--depth=1").arg(BOEHM_ATOMICS_REPO).current_dir(&boehm_src)
+        });
+    }
+
+    env::set_current_dir(&boehm_src).unwrap();
+
+    run("./autogen.sh", |cmd| cmd);
+    run("./configure", |cmd| {
+        cmd.arg("--enable-static")
+            .arg("--disable-shared")
+            .env("CFLAGS", format!("{} {}", POINTER_MASK, FPIC))
+    });
+
+    run("make", |cmd| cmd);
+
+    let mut libpath = PathBuf::from(&boehm_src);
+    libpath.push(BUILD_DIR);
+
+    println!("cargo:rustc-link-search=native={}", &libpath.as_path().to_str().unwrap());
+    println!("cargo:rustc-link-lib=static=gc");
 }

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -1,0 +1,12 @@
+#![stable(feature = "rust1", since = "1.0.0")]
+#![allow(missing_docs)]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+use crate::alloc_crate::boehm::GC_gcollect;
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::gc::*;
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub fn force_collect() {
+    unsafe { GC_gcollect() };
+}

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -456,6 +456,7 @@ pub mod env;
 pub mod error;
 pub mod ffi;
 pub mod fs;
+pub mod gc;
 pub mod io;
 pub mod net;
 pub mod num;


### PR DESCRIPTION
A common GC pattern is to pass a `Vec<T>` to a `Gc` to be managed by the collector. This requires the collector to register a finalizer in order to call `Vec`'s drop method - even if `needs_drop::<T>() == false`! This PR seeks to fix that by allowing the compiler to ignore `Vec<T>::drop` (and hence, remove the need to register a finalizer) if it is safe to do so.

To summarise how this works, this PR  does three things:
- A new trait `ManageableContents` is introduced in `libcore`, this is to be implemented on every `T` whose contents are safe to be allocated with Boehm and not be dropped. The name is utterly rubbish, and a placeholder for now -- feel free to come up with suggestions (I'd like it to be relatively terse).
- Stubs for the Boehm allocator are added to `liballoc` to allow the compiler to switch between Global and Boehm allocation. (this is incomplete while I work out some of the trickier intricacies of Rust linkage)
- A MIR transform is added which searches for `Vec<T>::new()` constructors in user code. When found, it checks if `T: ManageableContents` and, if so, will patch the constructor to create a `RawVec` with a `Boehm` backing allocator.  (This patched function is currently using a placeholder which will abort the program when run in order to get `x.py check` to play nice until I've solved the static linkage issue.

This is a draft PR for now, since it doesn't build. However, I'm curious to see what you think about this particular approach.