### PR TITLE
Prevent registering of unnecessary finalizers for `Gc<Vec<T>>`

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -125,6 +125,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(gc)]
 
 // Allow testing this library
 

--- a/src/libcore/gc.rs
+++ b/src/libcore/gc.rs
@@ -1,10 +1,8 @@
 #![unstable(feature = "gc", issue = "none")]
 #![allow(missing_docs)]
 
-
-#[cfg(not(bootstrap))]
 #[unstable(feature = "gc", issue = "none")]
-#[lang = "manageable_contents"]
+#[cfg_attr(not(bootstrap), lang = "manageable_contents")]
 /// This trait can be implemented on types where it is safe to allow the allow the collector to
 /// free its memory and omit the drop method. This prevents the need to register a finalizer when
 /// managed by the Gc which is expensive.

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -9,7 +9,7 @@ pub use core::gc::*;
 #[unstable(feature = "gc", issue = "none")]
 pub use alloc_crate::gc::*;
 
-#[unstable(feature = "gc", reason = "gc", issue="none")]
+#[unstable(feature = "gc", reason = "gc", issue = "none")]
 pub fn force_collect() {
     unsafe { GC_gcollect() };
 }


### PR DESCRIPTION
This is the missing piece of the puzzle in order for `Gc<Vec<T>>` to optimise away finalizers on Gc values where `T: ManageableContents`. 

Up until this PR, `Vec`s could be pre-emptively allocated in a Gc region, but were still having finalizers registered anyway. Which caused some head-scratching as I wondered why this had 0 impact on wall-clock time when running a synthetic benchmark - oops! 