### PR TITLE
Automatically determine when finalizers can be omitted

### DIFF
--- a/src/librustc_mir/transform/preallocate_gc_contents.rs
+++ b/src/librustc_mir/transform/preallocate_gc_contents.rs
@@ -17,8 +17,11 @@ pub struct GcPreallocator;
 
 impl<'tcx> MirPass<'tcx> for GcPreallocator {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut BodyAndCache<'tcx>) {
-        let param_env = tcx.param_env(source.def_id()).with_reveal_all();
+        if !tcx.sess.opts.debugging_opts.gc_destination_propagation {
+            return;
+        }
 
+        let param_env = tcx.param_env(source.def_id()).with_reveal_all();
         GcPatcher { tcx, source, param_env }.run_pass(body);
     }
 }

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -973,4 +973,6 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "link native libraries in the linker invocation (default: yes)"),
     src_hash_algorithm: Option<SourceFileHashAlgorithm> = (None, parse_src_file_hash, [TRACKED],
         "hash algorithm of source files in debug info (`md5`, or `sha1`)"),
+    gc_destination_propagation: bool = (false, parse_bool, [TRACKED],
+        "only enable this if Boehm is the global allocator"),
 }


### PR DESCRIPTION
This PR introduces support for optimising away finalizers for Vecs whose element
types can be statically determined not to need dropping.

This requires the user to specify `Boehm` as the global allocator in their
crate, and the -Zgc-destination-propagation flag must be enabled.

Right now, this won't work recursively. In other words, if one were to create a
value with the following type:

    Gc<Vec<Vec<usize>>

A finalizer would still be registered unnecessarily.

This is because the MIR pass which determines which Vecs are allocated directly
in GC space currently looks only at the top-level element type inside a Vec.

    Gc<Vec<Vec<usize>>
        ^   ^
        |   |
        |   +---- No Finalizer
        +----- Finalizer

In order for both finalizers to be removed, one must implement
`ManageableContents` for `Vec<usize>`.
