### PR TITLE
Pave the way for users to opt-out of finalization

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -191,6 +191,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
             | sym::pref_align_of
             | sym::min_align_of
             | sym::needs_drop
+            | sym::needs_finalizer
             | sym::type_id
             | sym::type_name
             | sym::variant_count => {

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -206,6 +206,7 @@ language_item_table! {
     Freeze,                  sym::freeze,              freeze_trait,               Target::Trait;
 
     Drop,                    sym::drop,                drop_trait,                 Target::Trait;
+    NoFinalize,              sym::no_finalize,         no_finalize_trait,          Target::Trait;
 
     CoerceUnsized,           sym::coerce_unsized,      coerce_unsized_trait,       Target::Trait;
     DispatchFromDyn,         sym::dispatch_from_dyn,   dispatch_from_dyn_trait,    Target::Trait;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -898,9 +898,17 @@ rustc_queries! {
         query is_freeze_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` is freeze", env.value }
         }
+        /// Query backing `TyS::is_no_finalize`.
+        query is_no_finalize_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+            desc { "computing whether `{}` is `NoFinalize`", env.value }
+        }
         /// Query backing `TyS::needs_drop`.
         query needs_drop_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` needs drop", env.value }
+        }
+        /// Query backing `TyS::needs_finalizer`.
+        query needs_finalizer_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+            desc { "computing whether `{}` needs finalizer", env.value }
         }
 
         /// Query backing `TyS::is_structural_eq_shallow`.
@@ -919,6 +927,15 @@ rustc_queries! {
         /// then `Err(AlwaysRequiresDrop)` is returned.
         query adt_drop_tys(def_id: DefId) -> Result<&'tcx ty::List<Ty<'tcx>>, AlwaysRequiresDrop> {
             desc { |tcx| "computing when `{}` needs drop", tcx.def_path_str(def_id) }
+            cache_on_disk_if { true }
+        }
+
+        /// A list of types where the ADT requires finalization when used with
+        /// GC if and only if any of those types require finalization. If the
+        /// ADT is known to always need finalization then
+        /// `Err(AlwaysRequiresDrop)` is returned.
+        query adt_finalize_tys(def_id: DefId) -> Result<&'tcx ty::List<Ty<'tcx>>, AlwaysRequiresDrop> {
+            desc { |tcx| "computing when `{}` needs finalize", tcx.def_path_str(def_id) }
             cache_on_disk_if { true }
         }
 

--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -61,6 +61,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
             ConstValue::Slice { data: alloc, start: 0, end: alloc.len() }
         }
         sym::needs_drop => ConstValue::from_bool(tp_ty.needs_drop(tcx, param_env)),
+        sym::needs_finalizer => ConstValue::from_bool(tp_ty.needs_finalizer(tcx, param_env)),
         sym::size_of | sym::min_align_of | sym::pref_align_of => {
             let layout = tcx.layout_of(param_env.and(tp_ty)).map_err(|e| err_inval!(Layout(e)))?;
             let n = match name {
@@ -136,6 +137,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             sym::min_align_of
             | sym::pref_align_of
             | sym::needs_drop
+            | sym::needs_finalizer
             | sym::size_of
             | sym::type_id
             | sym::type_name
@@ -146,6 +148,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         self.tcx.types.usize
                     }
                     sym::needs_drop => self.tcx.types.bool,
+                    sym::needs_finalizer => self.tcx.types.bool,
                     sym::type_id => self.tcx.types.u64,
                     sym::type_name => self.tcx.mk_static_str(),
                     _ => bug!("already checked for nullary intrinsics"),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -698,6 +698,7 @@ symbols! {
         nearbyintf64,
         needs_allocator,
         needs_drop,
+        needs_finalizer,
         needs_panic_runtime,
         neg,
         negate_unsigned,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -715,6 +715,7 @@ symbols! {
         no_crate_inject,
         no_debug,
         no_default_passes,
+        no_finalize,
         no_implicit_prelude,
         no_inline,
         no_link,

--- a/compiler/rustc_ty/src/common_traits.rs
+++ b/compiler/rustc_ty/src/common_traits.rs
@@ -18,6 +18,10 @@ fn is_freeze_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>
     is_item_raw(tcx, query, LangItem::Freeze)
 }
 
+fn is_no_finalize_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+    is_item_raw(tcx, query, LangItem::NoFinalize)
+}
+
 fn is_item_raw<'tcx>(
     tcx: TyCtxt<'tcx>,
     query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
@@ -37,5 +41,11 @@ fn is_item_raw<'tcx>(
 }
 
 pub(crate) fn provide(providers: &mut ty::query::Providers) {
-    *providers = ty::query::Providers { is_copy_raw, is_sized_raw, is_freeze_raw, ..*providers };
+    *providers = ty::query::Providers {
+        is_copy_raw,
+        is_sized_raw,
+        is_freeze_raw,
+        is_no_finalize_raw,
+        ..*providers
+    };
 }

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -73,6 +73,7 @@ pub fn intrinsic_operation_unsafety(intrinsic: Symbol) -> hir::Unsafety {
         | sym::size_of
         | sym::min_align_of
         | sym::needs_drop
+        | sym::needs_finalizer
         | sym::caller_location
         | sym::size_of_val
         | sym::min_align_of_val
@@ -192,6 +193,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             ),
             sym::drop_in_place => (1, vec![tcx.mk_mut_ptr(param(0))], tcx.mk_unit()),
             sym::needs_drop => (1, Vec::new(), tcx.types.bool),
+            sym::needs_finalizer => (1, Vec::new(), tcx.types.bool),
 
             sym::type_name => (1, Vec::new(), tcx.mk_static_str()),
             sym::type_id => (1, Vec::new(), tcx.types.u64),

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -7,3 +7,7 @@
 /// free its memory and omit the drop method. This prevents the need to register a finalizer when
 /// managed by the Gc which is expensive.
 pub trait ManageableContents {}
+
+#[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(bootstrap), lang = "no_finalize")]
+pub trait NoFinalize {}

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1084,6 +1084,13 @@ extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
     pub fn needs_drop<T>() -> bool;
 
+    /// Returns `true` if the actual type given as `T` requires finalization
+    /// inside GC; returns `false` if the actual type provided for `T`
+    /// implements `Copy`, has a destructor, or implements `NoFinalize`.
+    #[rustc_const_unstable(feature = "gc", issue = "none")]
+    #[cfg(not(bootstrap))]
+    pub fn needs_finalizer<T>() -> bool;
+
     /// Calculates the offset from a pointer.
     ///
     /// This is implemented as an intrinsic to avoid converting to and from an

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -102,6 +102,7 @@
 #![feature(duration_consts_2)]
 #![feature(extern_types)]
 #![feature(fundamental)]
+#![feature(gc)]
 #![feature(intrinsics)]
 #![feature(try_find)]
 #![feature(is_sorted)]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -580,6 +580,22 @@ pub const fn needs_drop<T>() -> bool {
     intrinsics::needs_drop::<T>()
 }
 
+/// Returns `false` if values of type `T` don't need finalizing when used within
+/// `Gc`, or `true` otherwise.
+///
+/// This is purely an optimization hint, and may be implemented conservatively:
+/// it may return `true` for types that don't actually need to be finalized.
+/// As such always returning `true` would be a valid implementation of
+/// this function. However if this function actually returns `false`, then you
+/// can be certain that omitting a finalizer for `T` has no side effect.
+#[inline]
+#[unstable(feature = "gc", issue = "none")]
+#[rustc_const_unstable(feature = "gc", issue = "none")]
+#[cfg(not(bootstrap))]
+pub const fn needs_finalizer<T>() -> bool {
+    intrinsics::needs_finalizer::<T>()
+}
+
 /// Returns the value of type `T` represented by the all-zero byte-pattern.
 ///
 /// This means that, for example, the padding byte in `(u8, u16)` is not

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -166,6 +166,7 @@ language_item_table! {
     FreezeTraitLangItem,         "freeze",             freeze_trait,            Target::Trait;
 
     DropTraitLangItem,           "drop",               drop_trait,              Target::Trait;
+    NoFinalizeTraitLangItem,     "no_finalize",        no_finalize_trait,       Target::Trait;
 
     CoerceUnsizedTraitLangItem,  "coerce_unsized",     coerce_unsized_trait,    Target::Trait;
     DispatchFromDynTraitLangItem,"dispatch_from_dyn",  dispatch_from_dyn_trait, Target::Trait;

--- a/src/test/ui/consts/const-needs_finalize.rs
+++ b/src/test/ui/consts/const-needs_finalize.rs
@@ -1,0 +1,48 @@
+// run-pass
+#![feature(gc)]
+
+use std::mem;
+
+struct NeedsDrop;
+
+impl Drop for NeedsDrop {
+    fn drop(&mut self) {}
+}
+
+struct Trivial(u8, f32);
+
+struct NonTrivial(u8, NeedsDrop);
+
+struct ExplicitNoFinalize(Trivial, NonTrivial);
+
+struct NestedNoFinalize(Trivial, ExplicitNoFinalize);
+
+impl core::gc::NoFinalize for ExplicitNoFinalize {}
+
+const CONST_U8: bool = mem::needs_finalizer::<u8>();
+const CONST_STRING: bool = mem::needs_finalizer::<String>();
+const CONST_TRIVIAL: bool = mem::needs_finalizer::<Trivial>();
+const CONST_NON_TRIVIAL: bool = mem::needs_finalizer::<NonTrivial>();
+
+static STATIC_U8: bool = mem::needs_finalizer::<u8>();
+static STATIC_STRING: bool = mem::needs_finalizer::<String>();
+static STATIC_TRIVIAL: bool = mem::needs_finalizer::<Trivial>();
+static STATIC_NON_TRIVIAL: bool = mem::needs_finalizer::<NonTrivial>();
+
+static STATIC_EXPLICIT_NO_FINALIZE: bool = mem::needs_finalizer::<ExplicitNoFinalize>();
+static STATIC_NESTED_NO_FINALIZE: bool = mem::needs_finalizer::<NestedNoFinalize>();
+
+fn main() {
+    assert!(!CONST_U8);
+    assert!(CONST_STRING);
+    assert!(!CONST_TRIVIAL);
+    assert!(CONST_NON_TRIVIAL);
+
+    assert!(!STATIC_U8);
+    assert!(STATIC_STRING);
+    assert!(!STATIC_TRIVIAL);
+    assert!(STATIC_NON_TRIVIAL);
+
+    assert!(!STATIC_EXPLICIT_NO_FINALIZE);
+    assert!(!STATIC_NESTED_NO_FINALIZE);
+}


### PR DESCRIPTION
Finalization can be very expensive, and when a `Gc` manages the memory for a particular type, it's not always obvious if a finalizer is required. Up until now, the collector will err on the side of caution: if unsure, it will register finalizers for types even when this may not be strictly necessary. 

To try and win back some of the performance we lose by being overly liberal with finalization, this PR provides an API for the user to tell the GC that values of a certain type don't need finalizing. It comes in two parts:

1. A `NoFinalize` marker trait which can be implemented on types where the user is sure finalization isn't necessary
2. A `needs_finalizer::<T>()` intrinsic, which, like `needs_drop`, will return `true` if `Gc<T>` should register a finalizer. This is semantically identical to `needs_drop` with one key difference: it takes into account whether `T` (or its components) implement `NoFinalize`.

This is only the first stage -- at present the GC won't do anything with this information.