### PR TITLE
Allow boehm::register_finalizer to take a null fn pointer

### DIFF
--- a/library/alloc/src/boehm.rs
+++ b/library/alloc/src/boehm.rs
@@ -25,7 +25,7 @@ pub unsafe fn gc_free(dead: *mut u8) {
 
 pub unsafe fn gc_register_finalizer(
     obj: *mut u8,
-    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
     client_data: *mut u8,
     old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
     old_client_data: *mut *mut u8,

--- a/library/boehm_shim/src/lib.rs
+++ b/library/boehm_shim/src/lib.rs
@@ -22,7 +22,7 @@ pub unsafe fn gc_free(dead: *mut u8) {
 
 pub unsafe fn gc_register_finalizer(
     obj: *mut u8,
-    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
     client_data: *mut u8,
     old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
     old_client_data: *mut *mut u8,
@@ -44,7 +44,7 @@ extern "C" {
 
     pub fn GC_register_finalizer(
         ptr: *mut u8,
-        finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
         client_data: *mut u8,
         old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
         old_client_data: *mut *mut u8,


### PR DESCRIPTION
This makes the API compatible with https://github.com/softdevteam/rboehm/pull/25