### PR TITLE
Replace gc_malloc_uncollectable with gc_malloc for non-GC'd values

### DIFF
--- a/library/alloc/src/boehm.rs
+++ b/library/alloc/src/boehm.rs
@@ -50,7 +50,7 @@ pub struct BoehmGcAllocator;
 #[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        unsafe { boehm_shim::gc_malloc_uncollectable(layout.size()) as *mut u8 }
+        unsafe { boehm_shim::gc_malloc(layout.size()) as *mut u8 }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {


### PR DESCRIPTION
At first this seems counter-intuitive: why put memory that should be
managed with RAII under control of the collector? However, this is
necessary to prevent leaks if we want to take advantage of `NoFinalize`
optimisations. This is best explained with an example:

    let bigvec: Vec<usize> = ...;
    let gc = Gc::new(bigvec);

Here, `bigvec` has a `drop` method which does the following: recursively
call drop on each element; then, deallocate the memory for the backing store
(`RawVec`). When `bigvec` is moved into `Gc`, its `drop` method is
converted from a destructor to a finalizer, and may run later on when
Boehm determines that it's no longer reachable. Unfortunately, this kind
of finalization is very expensive, and leads to bottlenecks in the
collector which can make it impractical to use.

The solution to this is to use the `NoFinalize` marker trait, e.g.:

    impl NoFinalize for Vec<usize> {}

This tells the collector that calling `bigvec`'s `drop` method is
unnecessary: there is no need to recursively call `drop` on the element
type (`usize`) since it's trivially destructable. This is essential to
win-back performance losses from excess finalization.

However, recursively calling drop on element types is only one part of
`Vec<usize>::drop`: it also deallocates the backing `RawVec`.  Omitting
the finalizer -- as would be the case when marked `NoFinalize` -- means
that the `RawVec`'s memory will leak. This is why we now allocate *all*
memory through `gc_malloc`. From now on, just like with `Gc` values, the
`RawVec` will be reclaimed when the collector sees that it is
unreachable.

There are two major concerns about this change which immediately jump out:

    

1. We now have non-deterministic freeing for RAII values, which
    breaks a users mental model of how Rust does memory.

2. Using `gc_malloc` to manage non-gc'd memory will have performance
    overhead.

Fortunately, I think these concerns are unfounded. First, `gc_free`
works with `gc_malloc`, just as it does with `gc_malloc_uncollectable`,
and we *have not* removed `free` calls for standard non-gc Rust
allocation. In essence, this is identical to what we had before with the
exception that leaks are cleaned up later on by the collector.

Second, the performance costs of using `gc_malloc` over
`gc_malloc_uncollectable` are not hugely different, since blocks
allocated with the latter call are still scanned for GC pointers during
marking anyway. The table below shows a comparison of using `gc_malloc`
and `gc_malloc_uncollectable` for non-GC'd rust values with no
additional optimizations.
```
--------------------------------------------------------------------------------
  Benchmark     Executor                  Suite   Extra   Core  #Smpls Mean (ms)
--------------------------------------------------------------------------------
  Bounce        gc_malloc                 micro       2      1   10          71
  Bounce        gc_malloc_uncollectable   micro       2      1   10         105
  BubbleSort    gc_malloc                 micro       3      1   10          81
  BubbleSort    gc_malloc_uncollectable   micro       3      1   10         100
  DeltaBlue     gc_malloc                 macro      50      1   10          90
  DeltaBlue     gc_malloc_uncollectable   macro      50      1   10         109
  Dispatch      gc_malloc                 micro       2      1   10          46
  Dispatch      gc_malloc_uncollectable   micro       2      1   10          73
  Fannkuch      gc_malloc                 micro       6      1   10          54
  Fannkuch      gc_malloc_uncollectable   micro       6      1   10          53
  Fibonacci     gc_malloc                 micro       3      1   10         226
  Fibonacci     gc_malloc_uncollectable   micro       3      1   10         232
  FieldLoop     gc_malloc                 micro       1      1   10          36
  FieldLoop     gc_malloc_uncollectable   micro       1      1   10          55
  GraphSearch   gc_malloc                 macro       4      1   10          24
  GraphSearch   gc_malloc_uncollectable   macro       4      1   10          27
  IntegerLoop   gc_malloc                 micro       2      1   10          89
  IntegerLoop   gc_malloc_uncollectable   micro       2      1   10         147
  JsonSmall     gc_malloc                 macro       1      1   10          99
  JsonSmall     gc_malloc_uncollectable   macro       1      1   10         102
  List          gc_malloc                 micro       2      1   10         106
  List          gc_malloc_uncollectable   micro       2      1   10         109
  Loop          gc_malloc                 micro       5      1   10         130
  Loop          gc_malloc_uncollectable   micro       5      1   10         170
  Mandelbrot    gc_malloc                 micro      30      1   10         121
  Mandelbrot    gc_malloc_uncollectable   micro      30      1   10         183
  NBody         gc_malloc                 macro     500      1   10          65
  NBody         gc_malloc_uncollectable   macro     500      1   10          64
  PageRank      gc_malloc                 macro      40      1   10         107
  PageRank      gc_malloc_uncollectable   macro      40      1   10         113
  Permute       gc_malloc                 micro       3      1   10          93
  Permute       gc_malloc_uncollectable   micro       3      1   10         111
  Queens        gc_malloc                 micro       2      1   10          69
  Queens        gc_malloc_uncollectable   micro       2      1   10          95
  QuickSort     gc_malloc                 micro       1      1   10          33
  QuickSort     gc_malloc_uncollectable   micro       1      1   10          40
  Recurse       gc_malloc                 micro       3      1   10          67
  Recurse       gc_malloc_uncollectable   micro       3      1   10          96
  Richards      gc_malloc                 macro       1      1   10        2247
  Richards      gc_malloc_uncollectable   macro       1      1   10        2282
  Sieve         gc_malloc                 micro       4      1   10         131
  Sieve         gc_malloc_uncollectable   micro       4      1   10         185
  Storage       gc_malloc                 micro       1      1   10          61
  Storage       gc_malloc_uncollectable   micro       1      1   10          53
  Sum           gc_malloc                 micro       2      1   10          45
  Sum           gc_malloc_uncollectable   micro       2      1   10          72
  Towers        gc_malloc                 micro       2      1   10         111
  Towers        gc_malloc_uncollectable   micro       2      1   10         116
  TreeSort      gc_malloc                 micro       1      1   10         150
  TreeSort      gc_malloc_uncollectable   micro       1      1   10         143
  WhileLoop     gc_malloc                 micro      10      1   10         108
  WhileLoop     gc_malloc_uncollectable   micro      10      1   10         171
```
Surprisingly, `gc_malloc` appears to perform better in a few benchmarks,
I'd speculate this is due to locality since `gc_malloc_uncollectable`
always allocates in pages distinct from blocks which are gc managed.

This does feel a bit like using a sledgehammer to crack a nut: ideally
we would only want to replace `gc_malloc_uncollectable` with `gc_malloc`
for certain collections (like `Vec`) where this problem can arise.
Unfortunately, this is not practical until Rust provides a way to use
collections with custom allocators [1]. An even more ideal solution
would be to use this in combination with _destination propagation_:
allocating a value directly on the GC heap when it can be determined
statically that it gets moved into a GC. I've prototyped the latter (see
cb06b9), and right now, without proper custom allocation support, the
benefits don't justify the sheer complexity it adds.

[1]: https://github.com/rust-lang/rust/issues/32838