### PR TITLE
Mark Strings as NoFinalize

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -44,6 +44,7 @@
 
 use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use core::fmt;
+use core::gc::NoFinalize;
 use core::hash;
 use core::iter::{FromIterator, FusedIterator};
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -2507,3 +2508,6 @@ impl From<char> for String {
         c.to_string()
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+impl NoFinalize for String {}

--- a/src/test/ui/consts/const-needs_finalize.rs
+++ b/src/test/ui/consts/const-needs_finalize.rs
@@ -34,12 +34,12 @@ static STATIC_NESTED_NO_FINALIZE: bool = mem::needs_finalizer::<NestedNoFinalize
 
 fn main() {
     assert!(!CONST_U8);
-    assert!(CONST_STRING);
+    assert!(!CONST_STRING);
     assert!(!CONST_TRIVIAL);
     assert!(CONST_NON_TRIVIAL);
 
     assert!(!STATIC_U8);
-    assert!(STATIC_STRING);
+    assert!(!STATIC_STRING);
     assert!(!STATIC_TRIVIAL);
     assert!(STATIC_NON_TRIVIAL);
 


### PR DESCRIPTION
A String in Rust is implemented as a `Vec<u8>`. This doesn't need
finalizing when used in a Gc. Marking it with `NoFinalize` will ensure
that `mem::needs_finalizer::<String>()` returns `false`.